### PR TITLE
Resolve find/replace boo-boo

### DIFF
--- a/components/ajax-progress-throbber/src/scripts.js
+++ b/components/ajax-progress-throbber/src/scripts.js
@@ -6,7 +6,7 @@
  */
 (($, Drupal, drupalSettings) => {
 
-  Drupal.theme.ajaxProgressThrobber = () => `<span class="ajax-progress-throbber">${drupalSettings.onlineEducation.spinner_component}</span>`;
+  Drupal.theme.ajaxProgressThrobber = () => `<span class="ajax-progress-throbber">${drupalSettings.online_education.spinner_component}</span>`;
 
   Drupal.Ajax.prototype.setProgressIndicatorThrobber = function() {
     this.progress.element = $(Drupal.theme('ajaxProgressThrobber'));

--- a/online_education.theme
+++ b/online_education.theme
@@ -83,7 +83,7 @@ function online_education_library_info_build(): array {
  */
 function online_education_js_settings_alter(array &$settings): void {
 
-  if (array_key_exists('onlineEducation', $settings) && array_key_exists('spinner_component', $settings['onlineEducation'])) {
+  if (array_key_exists('online_education', $settings) && array_key_exists('spinner_component', $settings['online_education'])) {
     $spinner = [
       '#type' => 'inline_template',
       '#template' => <<<TEMPLATE
@@ -93,7 +93,7 @@ function online_education_js_settings_alter(array &$settings): void {
       } only %}
     TEMPLATE,
     ];
-    $settings['onlineEducation']['spinner_component'] = \Drupal::service('renderer')->renderPlain($spinner);
+    $settings['online_education']['spinner_component'] = \Drupal::service('renderer')->renderPlain($spinner);
   }
 }
 


### PR DESCRIPTION
The `drupalSettings` key that we're adding in the libraries.yml file is under `online_education`, but the hooks are checking for `onlineEducation`.  This leads to AJAX errors.

To resolve, I'm just normalizing the casing in the hooks.